### PR TITLE
Prevent errors with tax rate 0%

### DIFF
--- a/src/CoreShop/Payum/KlarnaCOBundle/Extension/AuthorizeExtension.php
+++ b/src/CoreShop/Payum/KlarnaCOBundle/Extension/AuthorizeExtension.php
@@ -93,7 +93,12 @@ final class AuthorizeExtension implements ExtensionInterface
             }
 
             $rates = array_map(function(TaxItemInterface $taxItem) { return $taxItem->getRate(); }, $itemTaxes);
-            $rate = (int)round((array_sum($rates) / count($rates)) * 100, 0);
+            if(count($rates) != 0){
+                $rate = (int)round((array_sum($rates) / count($rates)) * 100, 0);
+            }
+            else{
+                $rate = 0;
+            }
 
             $items[] = [
                 'type' => 'physical',


### PR DESCRIPTION
Does cause "Warning: Division by zero" otherwise.